### PR TITLE
Update CommunalHelper entities namespace

### DIFF
--- a/MoveBlockBarrier.cs
+++ b/MoveBlockBarrier.cs
@@ -22,8 +22,8 @@ namespace BrokemiaHelper {
             "Celeste.Mod.CommunalHelper.Entities.MoveSwapBlock, CommunalHelper, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
             "Celeste.Mod.CommunalHelper.Entities.CassetteMoveBlock, CommunalHelper, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
             "Celeste.Mod.CommunalHelper.Entities.DreamMoveBlock, CommunalHelper, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-            "Celeste.Mod.CommunalHelper.Entities.ConnectedStuff.EquationMoveBlock, CommunalHelper, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-            "Celeste.Mod.CommunalHelper.ConnectedMoveBlock, CommunalHelper, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "Celeste.Mod.CommunalHelper.Entities.EquationMoveBlock, CommunalHelper, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+            "Celeste.Mod.CommunalHelper.Entities.ConnectedMoveBlock, CommunalHelper, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
             // Crystalline Helper
             "vitmod.VitMoveBlock, vitmod, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
             // Dzhake Helper


### PR DESCRIPTION
All entities from Communal Helper were moved to the same namespace for consistency, and this PR updates the expected namespaces accordingly for Brokemia Helper.